### PR TITLE
Fixes issue with Missing Parameter

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -20,7 +20,7 @@ use std::str;
 /// assert_eq!(expected, hex::encode(pub_pem.as_slice()));
 /// ```
 pub fn get_public_key_from_hex(public_key: &str) -> Vec<u8> {
-    let public_number: BigNum = match BigNum::from_hex_str(&public_key) {
+    let public_number: BigNum = match BigNum::from_hex_str(public_key) {
         Ok(bn) => bn,
         Err(error) => panic!(
             "Error during parsing public key in hex, please check your configuration: {:?}",
@@ -54,7 +54,7 @@ pub fn get_public_key_from_hex(public_key: &str) -> Vec<u8> {
 /// assert_eq!(expected, hex::encode(pem.as_slice()));
 /// ```
 pub fn get_private_key_pem(private_key: &str) -> Vec<u8> {
-    let private_number: BigNum = match BigNum::from_hex_str(&private_key) {
+    let private_number: BigNum = match BigNum::from_hex_str(private_key) {
         Ok(bn) => bn,
         Err(error) => panic!(
             "Error during parsing private key in hex, please check your configuration: {:?}",
@@ -88,8 +88,8 @@ pub fn get_private_key_pem(private_key: &str) -> Vec<u8> {
 }
 
 pub fn decode(token: &str, pub_key: &str) -> Result<(JsonValue, JsonValue), CivicError> {
-    let public_key = get_public_key_from_hex(&pub_key);
-    let validate_result = jwt::validate_signature(&token, &public_key, frank_jwt::Algorithm::ES256);
+    let public_key = get_public_key_from_hex(pub_key);
+    let validate_result = jwt::validate_signature(token, &public_key, frank_jwt::Algorithm::ES256);
 
     if validate_result.is_err() {
         return Err(CivicError {
@@ -106,7 +106,7 @@ pub fn decode(token: &str, pub_key: &str) -> Result<(JsonValue, JsonValue), Civi
     }
 
     let result = jwt::decode(
-        &token,
+        token,
         &public_key,
         frank_jwt::Algorithm::ES256,
         &frank_jwt::ValidationOptions::default(),

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -105,7 +105,12 @@ pub fn decode(token: &str, pub_key: &str) -> Result<(JsonValue, JsonValue), Civi
         });
     }
 
-    let result = jwt::decode(&token, &public_key, frank_jwt::Algorithm::ES256);
+    let result = jwt::decode(
+        &token,
+        &public_key,
+        frank_jwt::Algorithm::ES256,
+        &frank_jwt::ValidationOptions::default(),
+    );
 
     if result.is_err() {
         return Err(CivicError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl CivicSip {
             "typ": "JWT"
         });
 
-        let private_key: Vec<u8> = crypto::get_private_key_pem(&self.config.private_key);
+        let private_key: Vec<u8> = crypto::get_private_key_pem(self.config.private_key);
         let jwt_token =
             match frank_jwt::encode(header, &private_key, &payload, frank_jwt::Algorithm::ES256) {
                 Ok(token) => token,
@@ -171,7 +171,7 @@ impl CivicSip {
             Err(error) => Err(error),
             Ok((_, jwt_payload)) => crypto::decrypt(
                 jwt_payload["data"].as_str().unwrap(),
-                &self.config.app_secret,
+                self.config.app_secret,
             ),
         }
     }


### PR DESCRIPTION
Looks like the Frank JWT library might have changed. `decode` now requires a validation option.  This PR updates the code to pass along the default validation options.

This PR also fixes Clippy warnings.